### PR TITLE
remove outdated Update Components section

### DIFF
--- a/frontend/src/data/docsContent.js
+++ b/frontend/src/data/docsContent.js
@@ -31,7 +31,6 @@ export const sidebarNav = [
       { id: "cli-push", label: "Push Components" },
       { id: "cli-pull", label: "Pull Components" },
       { id: "cli-list", label: "List Components" },
-      { id: "cli-update", label: "Update Components" },
     ],
   },
   {
@@ -178,15 +177,6 @@ composter pull buttons PrimaryButton`,
 # Example
 composter list buttons`,
   },
-
-   "cli-update": {
-     title: "Update Components",
-     description: "Replace an existing component with a new version.",
-     code: `composter update <category> <file-path>
-
- # Example
- composter update buttons ./src/Button.jsx`,
-   },
 
   // ============================================
   // DASHBOARD SECTION


### PR DESCRIPTION
## Description
Removed the outdated "Update Components" section from the CLI documentation and sidebar navigation.  

## Related Issue
Closes #40

## Type of Change
- UI improvement

## Screenshots

### Before:
<!-- Screenshot showing "Update Components" in sidebar / docs -->
<img width="1920" height="1020" alt="Screenshot 2025-12-24 002347" src="https://github.com/user-attachments/assets/02e547cf-8818-4fd5-bae0-9d11017a59c8" />


### After:
<!-- Screenshot showing section removed -->
<img width="1920" height="1020" alt="Screenshot 2025-12-24 002357" src="https://github.com/user-attachments/assets/537fb828-0585-4029-ac8e-c4de057bec69" />


## How Has This Been Tested?
- [x] Tested on desktop
- [x] Tested on mobile/tablet
- [x] Tested in multiple browsers
- [ ] Tested with keyboard navigation
- [ ] Tested with screen reader (not applicable)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have tested my changes locally
- [x] No console errors or warnings
- [x] Changes are responsive
