### PR TITLE
Fix auth login hang by eagerly initializing PG pool

### DIFF
--- a/api/auth/auth.js
+++ b/api/auth/auth.js
@@ -1,7 +1,7 @@
-import { betterAuth } from "better-auth"
-import { jwt } from "better-auth/plugins"
-import { Pool } from "pg"
+import { betterAuth } from "better-auth";
+import { jwt } from "better-auth/plugins";
 import dotenv from "dotenv";
+import database from "./database";
 dotenv.config();
 
 // Determine environment
@@ -9,21 +9,19 @@ const isProduction = process.env.NODE_ENV === "production";
 const AUTH_BASE_URL = process.env.BETTER_AUTH_URL || "http://localhost:3000";
 
 const auth = betterAuth({
-  database: new Pool({
-    connectionString: process.env.DATABASE_URL,
-  }),
+  database,
 
   baseURL: AUTH_BASE_URL,
 
   emailAndPassword: {
     enabled: true,
-    requireEmailVerification: false
+    requireEmailVerification: false,
   },
 
   trustedOrigins: [
     "http://localhost:5173",
     "https://composter.vercel.app",
-    process.env.CLIENT_URL
+    process.env.CLIENT_URL,
   ].filter(Boolean),
 
   session: {
@@ -40,26 +38,30 @@ const auth = betterAuth({
     useSecureCookies: isProduction,
     cookies: {
       session_token: {
-        name: isProduction ? "__Secure-better-auth.session_token" : "better-auth.session_token",
+        name: isProduction
+          ? "__Secure-better-auth.session_token"
+          : "better-auth.session_token",
         attributes: {
           httpOnly: true,
           sameSite: isProduction ? "none" : "lax",
           secure: isProduction,
           path: "/",
           maxAge: 60 * 60 * 24 * 30, // 30 days
-        }
+        },
       },
       session_data: {
-        name: isProduction ? "__Secure-better-auth.session_data" : "better-auth.session_data",
+        name: isProduction
+          ? "__Secure-better-auth.session_data"
+          : "better-auth.session_data",
         attributes: {
           httpOnly: true,
           sameSite: isProduction ? "none" : "lax",
           secure: isProduction,
           path: "/",
           maxAge: 60 * 60 * 24 * 30, // 30 days
-        }
-      }
-    }
+        },
+      },
+    },
   },
 
   plugins: [
@@ -68,8 +70,8 @@ const auth = betterAuth({
       issuer: AUTH_BASE_URL,
       audience: AUTH_BASE_URL,
       expirationTime: "30d", // 30 days to match session
-    })
+    }),
   ],
-})
+});
 
 export default auth;

--- a/api/auth/database.js
+++ b/api/auth/database.js
@@ -1,0 +1,17 @@
+import { Pool } from "pg";
+
+const database = await (async () => {
+  const pool = new Pool({
+    connectionString: process.env.DATABASE_URL,
+  });
+
+  const forceEagerInıt = async () => {
+    await pool.query("select 1");
+  };
+
+  await forceEagerInıt();
+
+  return pool;
+})();
+
+export default database;


### PR DESCRIPTION
## Problem
CLI login and auth requests sometimes hang indefinitely in current database initialization.

## Cause
`Better Auth` attempts to use the database before the first query is issued.
With the lazy Pool, the initial connection handshake never occurred, causing
requests to stall without errors.

## Fix
Initialize the Postgres pool eagerly at startup by forcing a dummy query
(`SELECT 1`) and exporting the ready pool instance as database.

This guarantees the database connection is established before auth handlers
are invoked.

## Impact
- Fixes hanging CLI login
- No behavior change for existing requests
- Minimal overhead (single startup query)