### PR TITLE
[FEAT] Enable Cascade Delete for Categories in Prisma

### DIFF
--- a/apps/api/prisma/migrations/20260124005501_init_database/migration.sql
+++ b/apps/api/prisma/migrations/20260124005501_init_database/migration.sql
@@ -1,0 +1,5 @@
+-- DropForeignKey
+ALTER TABLE "Component" DROP CONSTRAINT "Component_categoryId_fkey";
+
+-- AddForeignKey
+ALTER TABLE "Component" ADD CONSTRAINT "Component_categoryId_fkey" FOREIGN KEY ("categoryId") REFERENCES "Category"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -25,6 +25,6 @@ model Component {
   categoryId String
   userId     String
   createdAt  DateTime @default(now())
-  category   Category @relation(fields: [categoryId], references: [id])
+  category   Category @relation(fields: [categoryId], references: [id], onDelete: Cascade)
   @@unique([title, categoryId])
 }


### PR DESCRIPTION
- Add onDelete: Cascade to Component-Category relationship
- Apply database migration to sync schema
- Prevents orphaned components when categories are deleted

Closes #71