### PR TITLE
feat: UI auth flow test

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -37,7 +37,7 @@ export default defineConfig({
     video: 'on',
     screenshot: 'only-on-failure',
     connectOptions: process.env.CI ? undefined : {
-      wsEndpoint: 'ws://127.0.0.1:3000/',
+      wsEndpoint: 'ws://127.0.0.1:3001/',
     },
   },
 

--- a/tests/web/web-auth-flow.spec.ts
+++ b/tests/web/web-auth-flow.spec.ts
@@ -1,0 +1,53 @@
+import {test, expect} from "@playwright/test";
+import dotenv from "dotenv";
+import path from "path";
+
+dotenv.config({ path: path.resolve(__dirname, '../../apps/api/.env.test') });
+
+const getTestUser = () => {
+    return {
+        name: `UI Tester ${Date.now()}`,
+        email: `ui_test_${Date.now()}@example.com`,
+        password: 'Password123!'
+    }
+}
+
+const USER = getTestUser();
+
+test.describe('web auth flow test', ()=>{
+    test.describe.configure({ mode: 'serial' });    
+    
+    test('register new user', async({page})=>{
+        await page.goto('/signup');
+
+        const nameInput = page.getByLabel(/name/i);
+        const emailInput = page.getByLabel(/email/i);
+        const passwordInput = page.getByRole('textbox', { name: 'Password' });
+        const submitRegBtn = page.getByRole('button', {name: /create/i})    
+
+        await nameInput.fill(USER.name);
+        await emailInput.fill(USER.email);
+        await passwordInput.fill(USER.password);
+
+        await submitRegBtn.click();
+
+        await page.waitForURL('/app')
+        await expect(page).toHaveURL('/app')
+    })
+
+    test('login existing user', async({page})=>{
+        await page.goto('/login');
+
+        const emailInput = page.getByLabel(/email/i);
+        const passwordInput = page.getByRole('textbox', { name: 'Password' });
+        const submitLoginBtn = page.getByRole('button', {name: /sign in/i})    
+
+        await emailInput.fill(USER.email);
+        await passwordInput.fill(USER.password);
+
+        await submitLoginBtn.click();
+
+        await page.waitForURL('/app')
+        await expect(page).toHaveURL('/app')
+    })
+})


### PR DESCRIPTION
# 🧪 Test Contribution

## 📝 Description

**Fixed E2E Test Infrastructure and Added Web Auth Flow Tests**

This PR fixes multiple issues with the E2E test setup and adds comprehensive web authentication tests.

### Issues Fixed

| Issue | Root Cause | Solution |
| :--- | :--- | :--- |
| TypeScript error on `expect().status()` | Missing `await` before `request.post()` | Added `await` and fixed assertion syntax |
| Tests running in wrong order | Parallel execution of dependent tests | Added `test.describe.configure({ mode: 'serial' })` |
| Missing `name` field in sign-up | Better Auth requires name for registration | Added `name` to user object and request |
| Port conflict with Docker Playwright | Browser server and API both on 3000 | Moved Docker browser server to port 3001 |
| Browser can't reach frontend | Docker container using `localhost` | Uses `hostmachine` alias via `--add-host` |
| Missing `API_URL` env var | Tests couldn't find API endpoint | Added to `.env.test` |

### Changes Made

| File | Change |
| :--- | :--- |
| `tests/api/auth.spec.ts` | Added serial mode, `name` field, fixed `await` |
| `tests/web/web-auth-flow.spec.ts` | **[NEW]** Web auth flow tests (register + login) |
| `playwright.config.ts` | Docker browser server on port 3001, webServer config |
| `apps/api/.env.test` | Added `API_URL` env variable |
| `scripts/test-bootstrap.js` | Skip Docker in CI (uses service container) |
| `.github/workflows/ci.yml` | Added PostgreSQL service, env vars |

---

## 🎯 Test Type

- [x] 🟢 **E2E (Root)** - `npm run test:e2e`
- [ ] 🟡 **Unit (API)** - `npm run test:unit` (in apps/api)
- [ ] 🔵 **Unit (Web)** - `npm run test:unit` (in apps/web)

---

## ✅ Checklist

- [x] I have verified that the new test **passed** locally.
- [x] I have ensured that I didn't break existing tests.
- [x] (If E2E) I used the isolated test database mechanism.
- [x] I have cleansed any hardcoded secrets/IDs.

---
## Local Setup for Fedora

```bash
docker run --rm --network host --init -it mcr.microsoft.com/playwright:v1.58.0-jammy \
  /bin/sh -c "npx -y playwright@1.58.0 run-server --port 3001 --host 0.0.0.0"
  ```

## 📸 Screenshots / Trace


Fixes: #78 

